### PR TITLE
Avoid getting a longer eula.txt every time the server starts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 if [[ $EULA == 'true' ]]; then
+  echo "#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula)." > eula.txt
+  echo "#$(date +'%a %b %d %H:%M:%S %Z %Y')" >> eula.txt
   echo "eula=true" >> eula.txt
 fi
 


### PR DESCRIPTION
I would change this to avoid getting a longer and longer eula.txt every time the server starts. This small changes simply replaces the eula.txt on the server startup instead of adding `eula=true` to it every time.