### PR TITLE
Github Actions overhaul

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Build and Publish
 
 on:
   workflow_dispatch:
@@ -39,9 +39,10 @@ jobs:
       PROJECTID_IGNORE: ${{ github.event.inputs.projectIdIgnore }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out repository
+        uses: actions/checkout@v2
 
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -51,13 +52,14 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: artheus
+          username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build image
         run: |
           docker build . \
             -t curseforge/${PACK_NAME}:${PACK_VERSION} \
+            -t curseforge/${PACK_NAME}:latest \
             --build-arg JAVA_VERSION \
             --build-arg MINECRAFT_VERSION \
             --build-arg FORGE_VERSION \
@@ -66,10 +68,11 @@ jobs:
             --build-arg DOWNLOAD_URL \
             --build-arg PROJECTID_IGNORE
 
-      - name: Push to docker hub
+      - name: Push to Docker Hub
         run: docker push curseforge/${PACK_NAME}:${PACK_VERSION}
 
       - name: Push to Github Container Registry
         run: |
           docker tag curseforge/${PACK_NAME}:${PACK_VERSION} ghcr.io/curseforge-docker/${PACK_NAME}:${PACK_VERSION}
+          docker tag curseforge/${PACK_NAME}:${PACK_VERSION} ghcr.io/curseforge-docker/${PACK_NAME}:latest
           docker push ghcr.io/curseforge-docker/${PACK_NAME}:${PACK_VERSION}


### PR DESCRIPTION
- made the name more describing of this action
- moved the username for the Github Container Registry to the secrets to have userdata and code seperated and be analogous to the Docker Hub credentials
- fixed small typing inconsistencies with the Docker Hub name
- added name to checkout action
- added latest tags